### PR TITLE
Create pr for development and master on hotfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/bin/code
+++ b/bin/code
@@ -44,7 +44,7 @@ command :publish, :pr do |c|
     base_branch = nil
     base_branch = Code::Branch.master if options[:master]
 
-    $git.publish(branch: Code::Branch.current, base: base_branch, message: message)
+    $git.publish(base: base_branch, message: message)
   end
 end
 

--- a/lib/code/git.rb
+++ b/lib/code/git.rb
@@ -87,18 +87,27 @@ module Code
     end
 
     def pull_request(base:, message: '')
+      base = development_branch unless base
       message = current_branch.message if message.empty?
       command = "hub pull-request -f \"#{message}\" -b #{main_repo}:#{base} -h #{main_repo}:#{current_branch}"
       System.exec(command).strip
     end
 
     def generate_prs_for(base, message)
-      # if a base branch is passed, we only want to generate a pr against that branch
-      return System.open_in_browser pull_request(branch: current_branch, base: base, message: message) if base
-      
-      infer_base_branches.each do |base_branch|
-        System.open_in_browser pull_request(base: base_branch, message: message)
-      end
+      if current_branch.hotfix?
+        generate_hotfix_prs(message)
+      else
+        generate_feature_pr(base, message)
+      end  
+    end
+
+    def generate_feature_pr(base, message)
+      System.open_in_browser pull_request(base: base, message: message)
+    end
+
+    def generate_hotfix_prs(message)
+      System.open_in_browser pull_request(base: master_branch, message: message)
+      System.open_in_browser pull_request(base: development_branch, message: message)
     end
 
     def compare_in_browser(branch)
@@ -137,14 +146,6 @@ module Code
 
     def master_branch
       Branch.master
-    end
-
-    def infer_base_branches
-      if current_branch.hotfix?
-        [master_branch, development_branch]
-      else
-        [development_branch]
-      end
     end
 
     def prune_remote_branches

--- a/lib/code/git.rb
+++ b/lib/code/git.rb
@@ -79,7 +79,7 @@ module Code
       raise NotOnFeatureBranchError, 'Must be on a feature branch to publish your code' unless current_branch.feature?
       raise UncommittedChangesError, 'You have uncommitted changes' if uncommitted_changes?
       push
-      generate_prs_for(base, message)
+      create_prs_for(base, message)
     end
 
     def push
@@ -93,19 +93,19 @@ module Code
       System.exec(command).strip
     end
 
-    def generate_prs_for(base, message)
+    def create_prs_for(base, message)
       if current_branch.hotfix?
-        generate_hotfix_prs(message)
+        create_hotfix_prs(message)
       else
-        generate_feature_pr(base, message)
+        create_feature_pr(base, message)
       end  
     end
 
-    def generate_feature_pr(base, message)
+    def create_feature_pr(base, message)
       System.open_in_browser pull_request(base: base, message: message)
     end
 
-    def generate_hotfix_prs(message)
+    def create_hotfix_prs(message)
       System.open_in_browser pull_request(base: master_branch, message: message)
       System.open_in_browser pull_request(base: development_branch, message: message)
     end


### PR DESCRIPTION
When we create a merge a hotfix, the changes that were merged on master need to get merged into development. We're currently forgetting this in some cases, for example: last time I merged master into development for reissued, there was a list of old changes that were never merged into development.

This Pr changes the behavior of the `code pr`command when its applied on a hotfix by creating a PR against development in adition to the PR created against master branch.
