### PR TITLE
Implement "code pr" opening an existing pull request if one exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 ruby '2.1.1'
 gemspec
+gem "octokit"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.3.8)
     aruba (0.5.3)
       childprocess (>= 0.3.6)
       cucumber (>= 1.1.1)
@@ -22,6 +23,8 @@ GEM
       multi_json (>= 1.7.5, < 2.0)
       multi_test (>= 0.0.2)
     diff-lcs (1.2.4)
+    faraday (0.9.1)
+      multipart-post (>= 1.2, < 3)
     ffi (1.9.0)
     gherkin (2.12.1)
       multi_json (~> 1.3)
@@ -30,6 +33,9 @@ GEM
     json (1.8.0)
     multi_json (1.8.0)
     multi_test (0.0.2)
+    multipart-post (2.0.0)
+    octokit (3.8.0)
+      sawyer (~> 0.6.0, >= 0.5.3)
     rake (10.1.0)
     rdoc (4.0.1)
       json (~> 1.4)
@@ -41,6 +47,9 @@ GEM
     rspec-expectations (2.14.2)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.3)
+    sawyer (0.6.0)
+      addressable (~> 2.3.5)
+      faraday (~> 0.8, < 0.10)
 
 PLATFORMS
   ruby
@@ -48,6 +57,7 @@ PLATFORMS
 DEPENDENCIES
   aruba
   code!
+  octokit
   rake
   rdoc
   rspec

--- a/bin/code
+++ b/bin/code
@@ -44,7 +44,7 @@ command :publish, :pr do |c|
     base_branch = nil
     base_branch = Code::Branch.master if options[:master]
 
-    $git.publish(branch: Code::Branch.current, base: base_branch, message: message)
+    $git.publish(base: base_branch, message: message)
   end
 end
 

--- a/bin/code
+++ b/bin/code
@@ -13,6 +13,7 @@ rescue LoadError
 end
 
 require 'code/git'
+require 'code/github_api'
 require 'code/branch'
 require 'code/file_list'
 require 'code/system'
@@ -22,6 +23,22 @@ include GLI::App
 program_desc 'The Coderly Toolbelt'
 
 version Code::VERSION
+
+desc 'Authorize with GitHub'
+command :authorize, :login do |c|
+  c.flag 'username', desc: 'GitHub username'
+  c.flag 'password', desc: 'GitHub password'
+  c.action do |global_options, options, args|
+    puts "global_options: #{global_options}"
+    puts "options: #{options}"
+    puts "args: #{args}"
+
+    username = options[:username]
+    password = options[:password]
+
+    Code::GitHubAPI.authorize(username: username, password: password)
+  end
+end
 
 desc 'Describe some switch here'
 switch [:s,:switch]
@@ -44,7 +61,13 @@ command :publish, :pr do |c|
     base_branch = nil
     base_branch = Code::Branch.master if options[:master]
 
-    $git.publish(base: base_branch, message: message)
+    github_api = Code::GitHubAPI.new
+
+    if (github_api.current_branch_pr?)
+      Code::System.open_in_browser(github_api.current_branch_pr_url)
+    else
+      $git.publish(base: base_branch, message: message)
+    end
   end
 end
 

--- a/bin/code
+++ b/bin/code
@@ -32,7 +32,7 @@ command :authorize, :login do |c|
     username = options[:username]
     password = options[:password]
 
-    Code::GitHubAPI.authorize(username: username, password: password)
+    Code::GitHubAPI.new.authorize(username: username, password: password)
   end
 end
 

--- a/bin/code
+++ b/bin/code
@@ -29,10 +29,6 @@ command :authorize, :login do |c|
   c.flag 'username', desc: 'GitHub username'
   c.flag 'password', desc: 'GitHub password'
   c.action do |global_options, options, args|
-    puts "global_options: #{global_options}"
-    puts "options: #{options}"
-    puts "args: #{args}"
-
     username = options[:username]
     password = options[:password]
 

--- a/lib/code/git.rb
+++ b/lib/code/git.rb
@@ -87,18 +87,27 @@ module Code
     end
 
     def pull_request(base:, message: '')
+      base = development_branch unless base
       message = current_branch.message if message.empty?
       command = "hub pull-request -f \"#{message}\" -b #{main_repo}:#{base} -h #{main_repo}:#{current_branch}"
       System.exec(command).strip
     end
 
     def generate_prs_for(base, message)
-      # if a base branch is passed, we only want to generate a pr against that branch
-      return System.open_in_browser pull_request(branch: current_branch, base: base, message: message) if base
-      
-      infer_base_branches.each do |base_branch|
-        System.open_in_browser pull_request(base: base_branch, message: message)
-      end
+      if current_branch.hotfix?
+        generate_hotfix_prs(message)
+      else
+        generate_feature_pr(base, message)
+      end  
+    end
+
+    def generate_feature_pr(base, message)
+      System.open_in_browser pull_request(base: base, message: message)
+    end
+
+    def generate_hotfix_prs(message)
+      System.open_in_browser pull_request(base: master_branch, message: message)
+      System.open_in_browser pull_request(base: development_branch, message: message)
     end
 
     def compare_in_browser(branch)
@@ -137,14 +146,6 @@ module Code
 
     def master_branch
       Branch.master
-    end
-
-    def infer_base_branches
-      if current_branch.hotfix?
-        [master_branch, development_branch]
-      else
-        [development_branch]
-      end
     end
 
     def prune_remote_branches

--- a/lib/code/git.rb
+++ b/lib/code/git.rb
@@ -95,7 +95,7 @@ module Code
     def generate_prs_for(base, message)
       # if a base branch is passed, we only want to generate a pr against that branch
       return System.open_in_browser pull_request(branch: current_branch, base: base, message: message) if base
-      
+
       infer_base_branches.each do |base_branch|
         System.open_in_browser pull_request(base: base_branch, message: message)
       end

--- a/lib/code/git.rb
+++ b/lib/code/git.rb
@@ -79,7 +79,7 @@ module Code
       raise NotOnFeatureBranchError, 'Must be on a feature branch to publish your code' unless current_branch.feature?
       raise UncommittedChangesError, 'You have uncommitted changes' if uncommitted_changes?
       push
-      generate_prs_for(base, message)
+      create_prs_for(base, message)
     end
 
     def push
@@ -93,19 +93,19 @@ module Code
       System.exec(command).strip
     end
 
-    def generate_prs_for(base, message)
+    def create_prs_for(base, message)
       if current_branch.hotfix?
-        generate_hotfix_prs(message)
+        create_hotfix_prs(message)
       else
-        generate_feature_pr(base, message)
+        create_feature_pr(base, message)
       end  
     end
 
-    def generate_feature_pr(base, message)
+    def create_feature_pr(base, message)
       System.open_in_browser pull_request(base: base, message: message)
     end
 
-    def generate_hotfix_prs(message)
+    def create_hotfix_prs(message)
       System.open_in_browser pull_request(base: master_branch, message: message)
       System.open_in_browser pull_request(base: development_branch, message: message)
     end

--- a/lib/code/github_api.rb
+++ b/lib/code/github_api.rb
@@ -29,7 +29,7 @@ module Code
     end
 
     def current_branch_pr?
-      client = self.octokit_client_instance_from_token
+      client = octokit_client_instance_from_token
       client.pull_requests(current_repo, head: "#{current_organization}:#{current_branch}").any?
     end
 
@@ -47,7 +47,10 @@ module Code
 
     def current_organization
       organization_name = origin_url.split("/")[-2]
-      organization_name.sub!("git@github.com:","")
+
+      possible_prefix = "git@github.com:"
+      organization_name.sub!(possible_prefix,"")
+
       organization_name
     end
 

--- a/lib/code/github_api.rb
+++ b/lib/code/github_api.rb
@@ -46,11 +46,14 @@ module Code
     end
 
     def current_organization
-      origin_url.split('/')[-2]
+      organization_name = origin_url.split("/")[-2]
+      organization_name.sub!("git@github.com:","")
+      organization_name
     end
 
     def current_repo_name
-      origin_url.split("/")[-1].split('.')[0]
+      repo_name_with_extension = origin_url.split("/").last
+      repo_name_without_extension = repo_name_with_extension.sub(".git", "")
     end
 
     def current_repo

--- a/lib/code/github_api.rb
+++ b/lib/code/github_api.rb
@@ -1,0 +1,62 @@
+require "octokit"
+
+module Code
+
+  class GitHubAPI
+
+    AUTHORIZATION_NOTE = "Code gem authorization token"
+
+    def self.authorization_token=(token)
+      System.call("config --global oauth.token #{token}")
+    end
+
+    def self.octokit_client_instance_from_basic_auth(username:, password:)
+      client = Octokit::Client.new login: username, password: password
+    end
+
+    def self.authorize(username:, password:)
+      client = self.octokit_client_instance_from_basic_auth(username: username, password: password)
+
+      authorization = client.authorizations.detect { |auth| auth[:note] == AUTHORIZATION_NOTE}
+      if authorization
+        self.authorization_token = authorization[:token]
+      else
+        self.authorization_token = client.create_authorization(scopes: ["repo"], note: AUTHORIZATION_NOTE)[:token]
+      end
+    end
+
+    attr_accessor :origin_url
+    attr_accessor :authorization_token
+
+    def initialize
+      @origin_url = System.call("config --get remote.origin.url")
+      @authorization_token = System.call('config --get oauth.token')
+    end
+
+    def current_branch_pr_url
+      client = octokit_client_instance_from_token
+      client.pull_requests(current_repo, head: "#{current_organization}:#{Branch.current}")[0][:html_url]
+    end
+
+    def current_branch_pr?
+      client = self.octokit_client_instance_from_token
+      client.pull_requests(current_repo, head: "#{current_organization}:#{Branch.current}").any?
+    end
+
+    def current_organization
+      @origin_url.split('/')[-2]
+    end
+
+    def current_repo_name
+      @origin_url.split("/")[-1].split('.')[0]
+    end
+
+    def current_repo
+      "#{current_organization}/#{current_repo_name}"
+    end
+
+    def octokit_client_instance_from_token
+      client = Octokit::Client.new access_token: authorization_token
+    end
+  end
+end

--- a/lib/code/system.rb
+++ b/lib/code/system.rb
@@ -20,7 +20,13 @@ module Code
     end
 
     def open(item)
-      `open #{item}`
+      if (/darwin/ =~ RUBY_PLATFORM) != nil
+        command = "open"
+      elsif (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) == nil
+        command ="xdg-open"
+      end
+
+      `#{command} #{item}`
     end
 
     def exec(script)


### PR DESCRIPTION
## Description

Branching off of PR #8 to avoid potential trouble and to have something to make a PR out of (for testing). Nothing is implemented yet. In hindsight, this wasn't actually necessary.

The actuall changes are in 
- `Gemfile` - new gem
- `bin/code` - new `authorize` command, modification of the `publish` command
- `lib/github_api.rb` - new class for communicating with the GitHub API via the octokit gem.

Unfortunately, there is no simple way to find a PR from the command-line or via `hub`.  The only way this seems to be possible is through the GitHub API.

I actually contacted github and was promptly answered that this is exactly the case:

> Yep, that's possible, but you need to use the API:
> 
> https://developer.github.com/v3/pulls/#list-pull-requests
> 
> Notice that you can specify the head and/or the base branch for that API endpoint in the query parameters, which allows you to fetch the list of pull requests for those branches.
> 
> E.g. here's the pull request for the push-changes branch in github/linguist
> 
> https://api.github.com/repos/github/linguist/pulls?head=github:push-changes
> 
> Does that help?

Since that would mean we'd have to handle authentication on code side instead of relying on `hub` authentication, I found a gem called [github_api](https://github.com/peter-murach/github) as well as one called [octokit](https://github.com/octokit/octokit.rb). 

After some testing, I decided to go with the second one. It seems more developed and more robust than the first.
## Issues

Unfortunately, I have difficulties with code due to using linux, which I haven't realized I had before.
- The `open` console command does something on linux different compared to mac. The correct command to be used on my system is ˙xdg-open`, but some linux systems also have`gnome-open` and other variations.
- When doing a `code pr` to create a new pull request, hub prompts for username and password, it seems, but there's no actual prompt in the console for me. It just hangs there, allowing input, but not indicating what that input is. If I try typing in my credentials, I get various errors, but I haven't yet figured out how and what to type in to get past it.

Basically, code has issues on linux :)
## Flow

To elaborate, with this feature, the user is required to log in once, using 

```
code authorize --username "username" --password "password"
```

After that an oauth token will be created and stored into the global .gitconfig file. The token will be used to fetch and the proper pull request url and open it in browser.

I don't see a way around this, but I'm thinking there should also be a prompt in that case, to ask for credentials if `code pr` was called before `code authorize` being called first. Either that, or we make `code pr` accept a `--username` and `--password` option to and call `authorize` internally if it's needed and the options are provided, displaying an error otherwise.

Basically
- User calls `code pr`
- PR doesn't exist -> PR is created
- PR exists
  - If code is already authorized, open PR
  - If code is not already authorized
    - **Solution A** - user needs to pass in `--username` and `--password` with `code pr`. Authorization runs. If options are not passed in, code shows an error with the instruction to pass them in.
    - **Solution B** - user is prompted for username and password directly and then authorize gets called before code pr is fetched and open. I'm not sure how simple this is to implement.

**NOTE**: I decided to go with Solution A for the time being. It's faster to implement and more typical of command line behavior.
