### PR TITLE
Add code search command

### DIFF
--- a/bin/code
+++ b/bin/code
@@ -84,6 +84,13 @@ command :switch, :s do |c|
   end
 end
 
+desc "Opens the repository search interface on github"
+command :search do |c|
+  c.action do |global_options, options, args|
+    $git.search
+  end
+end
+
 desc 'Deploy to production'
 command :production do |c|
   c.action do |global_options, options, args|

--- a/lib/code/git.rb
+++ b/lib/code/git.rb
@@ -101,6 +101,10 @@ module Code
       end  
     end
 
+    def search
+      System.open_in_browser "https://github.com/#{current_repo}/find/development"
+    end
+
     def create_feature_pr(base, message)
       System.open_in_browser pull_request(base: base, message: message)
     end
@@ -162,6 +166,22 @@ module Code
 
     def repo_url(name)
       System.result("git ls-remote --get-url #{name}")
+    end
+
+    def origin_url
+      System.result("git config --get remote.origin.url")
+    end
+
+    def current_organization
+      origin_url.split('/')[-2].split(':')[1]
+    end
+
+    def current_repo_name
+      origin_url.split("/")[-1].split('.')[0]
+    end
+
+    def current_repo
+      "#{current_organization}/#{current_repo_name}"
     end
 
   end

--- a/lib/code/git.rb
+++ b/lib/code/git.rb
@@ -104,7 +104,7 @@ module Code
     end
 
     def search
-      System.open_in_browser "https://github.com/#{current_repo}/find/development"
+      System.open_in_browser "https://github.com/#current_repo_slug/find/development"
     end
 
     def create_feature_pr(base, message)
@@ -173,6 +173,10 @@ module Code
 
     def github_api
       @github_api ||= GitHubAPI.new
+    end
+
+    def current_repo_slug
+      Repository.current.slug
     end
 
   end

--- a/lib/code/git.rb
+++ b/lib/code/git.rb
@@ -104,7 +104,7 @@ module Code
     end
 
     def search
-      System.open_in_browser "https://github.com/#current_repo_slug/find/development"
+      System.open_in_browser "https://github.com/#{current_repo_slug}/find/development"
     end
 
     def create_feature_pr(base, message)

--- a/spec/code/git_spec.rb
+++ b/spec/code/git_spec.rb
@@ -92,9 +92,6 @@ module Code
 
       it 'should call System.open_in_browser with the proper url' do
         expect(System).to receive(:open_in_browser).with('https://github.com/testuser/codegit/find/development')
-
-        git = Git.new
-
         git.search
       end
     end

--- a/spec/code/git_spec.rb
+++ b/spec/code/git_spec.rb
@@ -84,5 +84,20 @@ module Code
 
     end
 
+    describe 'search' do
+
+      before do
+        allow(System).to receive(:open_in_browser)
+      end
+
+      it 'should call System.open_in_browser with the proper url' do
+        expect(System).to receive(:open_in_browser).with('https://github.com/testuser/codegit/find/development')
+
+        git = Git.new
+
+        git.search
+      end
+    end
+
   end
 end

--- a/spec/support/git_extras.rb
+++ b/spec/support/git_extras.rb
@@ -14,6 +14,7 @@ module Code
         System.exec 'touch README'
         System.call 'add -A'
         System.call 'commit -m "initial commit"'
+        System.call 'remote add origin https:/github.com/testuser/codegit'
       end
     end
 


### PR DESCRIPTION
This Pr adds the `code search`command which opens a github search interface for the repository, like:

https://github.com/coderly/code/find/development
