### PR TITLE
Refactored repository property parsing. Added specs

### DIFF
--- a/lib/code/github_api.rb
+++ b/lib/code/github_api.rb
@@ -9,7 +9,7 @@ module Code
 
     AUTHORIZATION_NOTE = "Code gem authorization token"
 
-    def initialize(repository: Repository.from_current_repository_url)
+    def initialize(repository: Repository.current)
       @repository = repository
     end
 

--- a/lib/code/repository.rb
+++ b/lib/code/repository.rb
@@ -1,0 +1,39 @@
+module Code
+
+  class Repository
+
+    def self.current_repository_url
+      System.result("git config --get remote.origin.url")
+    end
+
+    def self.from_current_repository_url
+      new(url: Repository.current_repository_url)
+    end
+
+    def initialize(url:)
+      @url = url
+    end
+
+    def organization
+      organization_name = @url.split("/")[-2]
+
+      possible_prefix = "git@github.com:"
+      organization_name.sub!(possible_prefix,"")
+
+      organization_name
+    end
+
+    def name
+      repo_name_with_extension = @url.split("/").last
+      repo_name_without_extension = repo_name_with_extension.sub(".git", "")
+
+      repo_name_without_extension
+    end
+
+    def slug
+      "#{organization}/#{name}"
+    end
+
+  end
+
+end

--- a/lib/code/repository.rb
+++ b/lib/code/repository.rb
@@ -2,12 +2,8 @@ module Code
 
   class Repository
 
-    def self.current_repository_url
-      System.result("git config --get remote.origin.url")
-    end
-
-    def self.from_current_repository_url
-      new(url: Repository.current_repository_url)
+    def self.current
+      new(url: System.result("git config --get remote.origin.url"))
     end
 
     def initialize(url:)

--- a/spec/code/repository_spec.rb
+++ b/spec/code/repository_spec.rb
@@ -13,6 +13,11 @@ module Code
         repo = Repository.new(url: "git@github.com:test_org/test_name.git")
         expect(repo.organization).to eq "test_org"
       end
+
+      it "works with file system paths" do
+        repo = Repository.new(url: "/home/random/path/to/git/test_org/test_name")
+        expect(repo.organization).to eq "test_org"
+      end
     end
 
     describe '#name' do
@@ -25,6 +30,11 @@ module Code
         repo = Repository.new(url: "git@github.com:test_org/test_name.git")
         expect(repo.name).to eq "test_name"
       end
+
+      it "works with file system paths" do
+        repo = Repository.new(url: "/home/random/path/to/git/test_org/test_name")
+        expect(repo.name).to eq "test_name"
+      end
     end
 
     describe '#slug' do
@@ -35,6 +45,11 @@ module Code
 
       it "works with 'git@github.com:' format repository urls" do
         repo = Repository.new(url: "git@github.com:test_org/test_name.git")
+        expect(repo.slug).to eq "test_org/test_name"
+      end
+
+      it "works with file system paths" do
+        repo = Repository.new(url: "/home/random/path/to/git/test_org/test_name")
         expect(repo.slug).to eq "test_org/test_name"
       end
     end

--- a/spec/code/repository_spec.rb
+++ b/spec/code/repository_spec.rb
@@ -1,0 +1,43 @@
+require 'code/repository'
+
+module Code
+  describe Repository do
+
+    describe '#organization' do
+      it "works with 'https://' format repository urls" do
+        repo = Repository.new(url: "https:/github.com/test_org/test_name.git")
+        expect(repo.organization).to eq "test_org"
+      end
+
+      it "works with 'git@github.com:' format repository urls" do
+        repo = Repository.new(url: "git@github.com:test_org/test_name.git")
+        expect(repo.organization).to eq "test_org"
+      end
+    end
+
+    describe '#name' do
+      it "works with 'https://' format repository urls" do
+        repo = Repository.new(url: "https:/github.com/test_org/test_name.git")
+        expect(repo.name).to eq "test_name"
+      end
+
+      it "works with 'git@github.com:' format repository urls" do
+        repo = Repository.new(url: "git@github.com:test_org/test_name.git")
+        expect(repo.name).to eq "test_name"
+      end
+    end
+
+    describe '#slug' do
+      it "works with 'https://' format repository urls" do
+        repo = Repository.new(url: "https:/github.com/test_org/test_name.git")
+        expect(repo.slug).to eq "test_org/test_name"
+      end
+
+      it "works with 'git@github.com:' format repository urls" do
+        repo = Repository.new(url: "git@github.com:test_org/test_name.git")
+        expect(repo.slug).to eq "test_org/test_name"
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
I tried to write a test as is and it turned out to be complicated. Instead of trying to find a solution, I decided to rewrite the code a bit to make it more easily testable.

I've added a repository class which takes in a URL and creates properties for parsing organization, repo name and repo slug (organization/name) from that URL.

This class is now very easily testable, and I tried to write it spec first, so we have specs for all the cases we currently support. I'll do some research and see if any other git repository URL format is possible on some systems and see if I can add support for those formats as well.

~~A local (in a different folder) repository is the first one that comes to mind.~~ I added specs for this and it works out of the box.
