### PR TITLE
Loosened ruby version requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: ruby
 rvm:
-  - 2.1.1
+  - 2.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: ruby
-rvm:
-  - 2.1
+before_install:
+	- rvm install 2.1.5

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
-ruby '2.1.1'
+ruby '2.1'
 gemspec
 gem "octokit"


### PR DESCRIPTION
We want to allow a less strict ruby version requirement, just ruby 2.1, and still allow this to pass on Travis.
