### PR TITLE
Switch login to username password

### DIFF
--- a/bin/code
+++ b/bin/code
@@ -41,7 +41,7 @@ command :publish, :pr do |c|
   c.switch [:master], desc: 'Make the pull request based off the master branch'
   c.action do |global_options, options, args|
 
-    $gitHubAPI.ensure_authorized
+    $github_api.ensure_authorized
 
     message = args.join(' ')
 
@@ -67,7 +67,7 @@ end
 desc "Marks the current branch's pr as awaiting review"
 command :ready do |c|
   c.action do |global_options, options, args|
-    $gitHubAPI.ensure_authorized
+    $github_api.ensure_authorized
     Code::Branch.current.mark_prs_as_awaiting_review
   end
 end
@@ -145,7 +145,7 @@ end
 
 pre do |global, command, options, args|
   $git = Code::Git.new
-  $gitHubAPI = Code::GitHubAPI.new
+  $github_api = Code::GitHubAPI.new
   true
 end
 

--- a/bin/code
+++ b/bin/code
@@ -75,7 +75,6 @@ end
 desc "Quickly create a pull request from your changes on development."
 command :hotfix, :fix do |c|
   c.action do |global_options, options, args|
-    $gitHubAPI.ensure_authorized
     hotfix_name = args.join('-')
     $git.hotfix hotfix_name
   end

--- a/bin/code
+++ b/bin/code
@@ -24,18 +24,6 @@ program_desc 'The Coderly Toolbelt'
 
 version Code::VERSION
 
-desc 'Authorize with GitHub'
-command :authorize, :login do |c|
-  c.flag 'username', desc: 'GitHub username'
-  c.flag 'password', desc: 'GitHub password'
-  c.action do |global_options, options, args|
-    username = options[:username]
-    password = options[:password]
-
-    Code::GitHubAPI.new.authorize(username: username, password: password)
-  end
-end
-
 desc 'Describe some switch here'
 switch [:s,:switch]
 
@@ -52,6 +40,9 @@ desc 'Upload your feature branch to GitHub'
 command :publish, :pr do |c|
   c.switch [:master], desc: 'Make the pull request based off the master branch'
   c.action do |global_options, options, args|
+
+    $gitHubAPI.ensure_authorized
+
     message = args.join(' ')
 
     base_branch = nil
@@ -76,6 +67,7 @@ end
 desc "Marks the current branch's pr as awaiting review"
 command :ready do |c|
   c.action do |global_options, options, args|
+    $gitHubAPI.ensure_authorized
     Code::Branch.current.mark_prs_as_awaiting_review
   end
 end
@@ -83,6 +75,7 @@ end
 desc "Quickly create a pull request from your changes on development."
 command :hotfix, :fix do |c|
   c.action do |global_options, options, args|
+    $gitHubAPI.ensure_authorized
     hotfix_name = args.join('-')
     $git.hotfix hotfix_name
   end
@@ -146,6 +139,7 @@ end
 
 pre do |global, command, options, args|
   $git = Code::Git.new
+  $gitHubAPI = Code::GitHubAPI.new
   true
 end
 

--- a/lib/code/git.rb
+++ b/lib/code/git.rb
@@ -100,7 +100,7 @@ module Code
         create_hotfix_prs(message)
       else
         create_feature_pr(base, message)
-      end  
+      end
     end
 
     def create_feature_pr(base, message)

--- a/lib/code/github_api.rb
+++ b/lib/code/github_api.rb
@@ -1,7 +1,8 @@
-require "octokit"
 require "code/repository"
+require "code/system"
+
+require "octokit"
 require "securerandom"
-require "io/console"
 
 module Code
 
@@ -17,8 +18,8 @@ module Code
 
     def ensure_authorized
       if not authorized?
-        username = prompt 'GitHub username'
-        password = prompt_password 'GitHub password'
+        username = System.prompt 'GitHub username'
+        password = System.prompt_hidden 'GitHub password'
 
         authorize(username: username, password: password)
       end
@@ -81,17 +82,5 @@ module Code
       System.result("git config --global oauth.token #{token}")
     end
 
-    def prompt(prompt_text)
-      print prompt_text + ':'
-      input = gets
-      input.strip
-    end
-
-    def prompt_password(prompt_text)
-      print prompt_text + ':'
-      input = STDIN.noecho(&:gets)
-      puts
-      input.strip
-    end
   end
 end

--- a/lib/code/github_api.rb
+++ b/lib/code/github_api.rb
@@ -1,28 +1,32 @@
 require "octokit"
 require "code/repository"
+require "securerandom"
 
 module Code
 
   class GitHubAPI
 
-    NoAuthTokenError = Class.new(StandardError)
-
-    AUTHORIZATION_NOTE = "Code gem authorization token"
+    def authorization_note
+      "CoderlyCode-" + SecureRandom.uuid
+    end
 
     def initialize(repository: Repository.current)
       @repository = repository
     end
 
+    def ensure_authorized
+      if not authorized?
+        username = prompt 'GitHub username'
+        password = prompt 'GitHub password'
+
+        authorize(username: username, password: password)
+      end
+    end
+
     def authorize(username:, password:)
       client = self.octokit_client_instance_from_basic_auth(username: username, password: password)
 
-      authorization = client.authorizations.detect { |auth| auth[:note] == AUTHORIZATION_NOTE }
-
-      if authorization
-        token = authorization[:token]
-      else
-        token = client.create_authorization(scopes: ["repo"], note: AUTHORIZATION_NOTE)[:token]
-      end
+      token = client.create_authorization(scopes: ["repo"], note: authorization_note)[:token]
 
       puts "Successfully authorized with token #{token}"
       self.authorization_token = token
@@ -45,6 +49,10 @@ module Code
       add_label_to_pr(pull_request.number, label)
     end
 
+    def authorized?
+      !authorization_token.empty?
+    end
+
     private
 
     def current_organization
@@ -65,12 +73,17 @@ module Code
 
     def authorization_token
       token = System.result('git config --get oauth.token')
-      raise NoAuthTokenError, "Couldn't retrieve an authorization token. Make sure you authorize through 'code authorize --username {username} --password {password}' first" if System.command_failed?
       token
     end
 
     def authorization_token=(token)
       System.result("git config --global oauth.token #{token}")
+    end
+
+    def prompt(prompt_text)
+      print prompt_text + ':'
+      input = gets
+      input.strip
     end
   end
 end

--- a/lib/code/github_api.rb
+++ b/lib/code/github_api.rb
@@ -1,6 +1,7 @@
 require "octokit"
 require "code/repository"
 require "securerandom"
+require "io/console"
 
 module Code
 
@@ -17,7 +18,7 @@ module Code
     def ensure_authorized
       if not authorized?
         username = prompt 'GitHub username'
-        password = prompt 'GitHub password'
+        password = prompt_password 'GitHub password'
 
         authorize(username: username, password: password)
       end
@@ -83,6 +84,13 @@ module Code
     def prompt(prompt_text)
       print prompt_text + ':'
       input = gets
+      input.strip
+    end
+
+    def prompt_password(prompt_text)
+      print prompt_text + ':'
+      input = STDIN.noecho(&:gets)
+      puts
       input.strip
     end
   end

--- a/lib/code/system.rb
+++ b/lib/code/system.rb
@@ -1,3 +1,5 @@
+require "io/console"
+
 require 'code/system/os'
 
 module Code
@@ -8,9 +10,17 @@ module Code
 
     COLORS = {black: 30, red: 31, green: 32, yellow: 33, blue: 34, magenta: 35, teal: 36}
 
-    def prompt(*args)
-      print(*args)
-      gets
+    def prompt(prompt_text)
+      print prompt_text + ': '
+      input = gets
+      input.strip
+    end
+
+    def prompt_hidden(prompt_text)
+      print prompt_text + ': '
+      input = STDIN.noecho(&:gets)
+      puts ''
+      input.strip
     end
 
     def error(message)

--- a/lib/code/system.rb
+++ b/lib/code/system.rb
@@ -11,15 +11,15 @@ module Code
     COLORS = {black: 30, red: 31, green: 32, yellow: 33, blue: 34, magenta: 35, teal: 36}
 
     def prompt(prompt_text)
-      print prompt_text + ': '
+      print prompt_text + ": "
       input = gets
       input.strip
     end
 
     def prompt_hidden(prompt_text)
-      print prompt_text + ': '
-      input = STDIN.noecho(&:gets)
-      puts ''
+      print prompt_text + ": "
+      input = noecho_gets
+      puts ""
       input.strip
     end
 
@@ -50,6 +50,10 @@ module Code
 
     def puts(text)
       Kernel.puts text
+    end
+
+    def noecho_gets
+      STDIN.noecho(&:gets)
     end
 
     def call(params)

--- a/spec/code/github_api_spec.rb
+++ b/spec/code/github_api_spec.rb
@@ -13,7 +13,8 @@ module Code
 
         it 'should not call #authorize' do
           expect(api).not_to receive(:authorize)
-          expect(api).not_to receive(:prompt)
+          expect(System).not_to receive(:prompt)
+          expect(System).not_to receive(:prompt_text)
 
           api.ensure_authorized
         end
@@ -26,7 +27,8 @@ module Code
 
         it 'should call #authorize' do
           expect(api).to receive(:authorize)
-          expect(api).to receive(:prompt).twice
+          expect(System).to receive(:prompt).once
+          expect(System).to receive(:prompt_hidden).once
 
           api.ensure_authorized
         end

--- a/spec/code/github_api_spec.rb
+++ b/spec/code/github_api_spec.rb
@@ -1,0 +1,36 @@
+require 'code/github_api'
+
+module Code
+  describe GitHubAPI do
+    let(:api) { GitHubAPI.new }
+
+    describe '#ensure_authorized' do
+
+      context 'when system is authorized' do
+        before do
+          allow(api).to receive(:authorized?).and_return(true)
+        end
+
+        it 'should not call #authorize' do
+          expect(api).not_to receive(:authorize)
+          expect(api).not_to receive(:prompt)
+
+          api.ensure_authorized
+        end
+      end
+
+      context 'when system is not authorized' do
+        before do
+          allow(api).to receive(:authorized?).and_return(false)
+        end
+
+        it 'should call #authorize' do
+          expect(api).to receive(:authorize)
+          expect(api).to receive(:prompt).twice
+
+          api.ensure_authorized
+        end
+      end
+    end
+  end
+end

--- a/spec/code/system_spec.rb
+++ b/spec/code/system_spec.rb
@@ -1,0 +1,41 @@
+require "code/system"
+require "io/console"
+
+module Code
+	module System
+    describe "#prompt" do
+      it "should print the prompt, then ask for and return the input" do
+        expect(System).to receive(:print).with("Test: ").and_return("")
+        expect(System).to receive(:gets).and_return("test_user")
+        input = System.prompt "Test"
+        expect(input).to eq "test_user"
+      end
+
+      it "should strip special characters from the input" do
+        allow(System).to receive(:print).and_return("")
+        allow(System).to receive(:gets).and_return("test\n")
+
+        input = System.prompt ""
+        expect(input).to eq "test"
+      end
+    end
+
+    describe "#prompt_hidden" do
+      it "should print the prompt, ask for input without echo, print a new line and return the input" do
+        expect(System).to receive(:print).with("Test: ").and_return("")
+        expect(System).to receive(:noecho_gets).and_return("test_pass")
+        expect(System).to receive(:puts).and_return("")
+        input = System.prompt_hidden "Test"
+        expect(input).to eq "test_pass"
+      end
+
+      it "should strip special characters from the input" do
+        allow(System).to receive(:print).and_return("")
+        allow(System).to receive(:noecho_gets).and_return("test\n")
+
+        input = System.prompt_hidden ""
+        expect(input).to eq "test"
+      end
+    end
+  end
+end


### PR DESCRIPTION
- [Asana task: Switch code login method to a username/password prompt](https://app.asana.com/0/26202368814744/41896304172551)
# Description

This PR removes the authorize command and instead adds a prompt to commands that require github authentication.
- Affected commands - "publish", "hotfix" and "ready".
- On successful authentication, the oauth key is stored on the machine, so there is no prompt a second time.
# ToDo
- [x] Write more specs
- [x] Mask the password input
